### PR TITLE
Added timeout for pileup-producing step, increased memory allocation

### DIFF
--- a/workflow-varscan/CHANGELOG.md
+++ b/workflow-varscan/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.1.1 - 2020-04-06
+- Added timeout setting to mpileup concatenation step. 5 hr is not enough for some data
 ## 2.1 - 2020-04-02
 - Introduced compression of mpileup data to conserve disk space
 ## 2.0 - 2020-01-31

--- a/workflow-varscan/pom.xml
+++ b/workflow-varscan/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>varscan</artifactId>
-    <version>2.1</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/workflow-varscan/varscan.wdl
+++ b/workflow-varscan/varscan.wdl
@@ -104,7 +104,7 @@ input {
  String? samtools = "$SAMTOOLS_ROOT/bin/samtools"
  String region 
  Int jobMemory   = 18
- Int timeout      = 20
+ Int timeout     = 40
 }
 
 parameter_meta {
@@ -143,11 +143,13 @@ task concatMpileup {
 input {
  Array[File] filePaths
  Int jobMemory = 10
+ Int timeout   = 20
 }
 
 parameter_meta {
   filePaths: "Array of pileup files to concatenate"
   jobMemory: "memory in GB for this job"
+  timeout: "Timeout in hours, needed to override imposed limits"
 }
 
 command <<<
@@ -156,6 +158,7 @@ command <<<
 
 runtime {
  memory: "~{jobMemory} GB"
+ timeout: "~{timeout}"
 }
 
 output {
@@ -187,7 +190,7 @@ input {
   String? logFile          = "VARSCAN_SNV.log"
   String? varScan          = "$VARSCAN_ROOT/VarScan.jar"
   String? modules          = "varscan/2.4.2 java/8"
-  Int timeout              = 20
+  Int timeout              = 40
 }
 
 parameter_meta {
@@ -300,7 +303,7 @@ input {
   String? logFile = "VARSCAN_CNV.log"
   String? varScan = "$VARSCAN_ROOT/VarScan.jar"
   String? modules = "varscan/2.4.2 java/8"
-  Int timeout = 20
+  Int timeout = 40
 }
 
 parameter_meta {


### PR DESCRIPTION
This is version 2.1.1, mostly parameter tuning