### PR TITLE
Small change to vcf mergin step, added -Xmx option and unset JAVA_OPTIONS

### DIFF
--- a/workflow-varscan/README.md
+++ b/workflow-varscan/README.md
@@ -102,11 +102,13 @@ Parameter|Value|Default|Description
 `mergeIND.timeout`|Int|10|Timeout in hours, needed to override imposed limits
 `mergeSNPvcf.modules`|String|"picard/2.21.2 hg19/p13"|modules needed for this task
 `mergeSNPvcf.seqDictionary`|String|"$HG19_ROOT/hg19_random.dict"|.dict file for the reference in use
-`mergeSNPvcf.jobMemory`|Int|6|memory in GB for this job
+`mergeSNPvcf.jobMemory`|Int|12|memory in GB for this job
+`mergeSNPvcf.javaMemory`|Int|8|memory in GB for java VM
 `mergeSNPvcf.timeout`|Int|10|Timeout in hours, needed to override imposed limits
 `mergeINDvcf.modules`|String|"picard/2.21.2 hg19/p13"|modules needed for this task
 `mergeINDvcf.seqDictionary`|String|"$HG19_ROOT/hg19_random.dict"|.dict file for the reference in use
-`mergeINDvcf.jobMemory`|Int|6|memory in GB for this job
+`mergeINDvcf.jobMemory`|Int|12|memory in GB for this job
+`mergeINDvcf.javaMemory`|Int|8|memory in GB for java VM
 `mergeINDvcf.timeout`|Int|10|Timeout in hours, needed to override imposed limits
 `smoothData.varScan`|String|"$VARSCAN_ROOT/VarScan.jar"|Path to VarScan jar file
 `smoothData.modules`|String|"varscan/2.4.2 java/8 rstats/3.6"|Modules for this job

--- a/workflow-varscan/varscan.wdl
+++ b/workflow-varscan/varscan.wdl
@@ -229,13 +229,15 @@ input {
  String outputSuffix = "snp"
  String modules = "picard/2.21.2 hg19/p13"
  String seqDictionary = "$HG19_ROOT/hg19_random.dict"
- Int jobMemory = 6
+ Int jobMemory = 12
+ Int javaMemory = 8
  Int timeout   = 10
 }
 
 parameter_meta {
   filePaths: "Array of pileup files to concatenate"
   jobMemory: "memory in GB for this job"
+  javaMemory: "memory in GB for java VM"
   outputFile: "Name of the output file"
   outputSuffix: "Suffix to use for an output file: snp or indel"
   seqDictionary: ".dict file for the reference in use"
@@ -244,7 +246,8 @@ parameter_meta {
 }
 
 command<<<
- java -jar $PICARD_ROOT/picard.jar SortVcf I=~{sep=' I=' filePaths} SD=~{seqDictionary} O=~{outputFile}.~{outputSuffix}.vcf
+ unset _JAVA_OPTIONS
+ java -Xmx~{javaMemory}G -jar $PICARD_ROOT/picard.jar SortVcf I=~{sep=' I=' filePaths} SD=~{seqDictionary} O=~{outputFile}.~{outputSuffix}.vcf
 >>>
 
 runtime {

--- a/workflow-varscan/varscan.wdl
+++ b/workflow-varscan/varscan.wdl
@@ -246,6 +246,7 @@ parameter_meta {
 }
 
 command<<<
+ set -euxo pipefail
  unset _JAVA_OPTIONS
  java -Xmx~{javaMemory}G -jar $PICARD_ROOT/picard.jar SortVcf I=~{sep=' I=' filePaths} SD=~{seqDictionary} O=~{outputFile}.~{outputSuffix}.vcf
 >>>


### PR DESCRIPTION
Since we are using **gatk** for merging vcf files, need to take care of **_JAVA_OPTIONS** environment variable (unset it). Plus, adding javaMemory option for better memory management